### PR TITLE
Fix a few flaky tests

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -69,6 +69,7 @@ import java.util.Set;
 import static org.apache.dubbo.common.constants.CommonConstants.GROUP_KEY;
 import static org.apache.dubbo.common.extension.ExtensionLoader.getExtensionLoader;
 import static org.apache.dubbo.common.extension.ExtensionLoader.getLoadingStrategies;
+import static org.apache.dubbo.common.extension.ExtensionLoader.resetExtensionLoader;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -337,6 +338,7 @@ public class ExtensionLoaderTest {
 
         adaptive = loader.getAdaptiveExtension();
         assertTrue(adaptive instanceof AddExt3_ManualAdaptive);
+        ExtensionLoader.resetExtensionLoader(AddExt3.class);
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -256,6 +256,7 @@ public class ExtensionLoaderTest {
 
         assertThat(ext, instanceOf(AddExt1_ManualAdd1.class));
         assertEquals("Manual1", getExtensionLoader(AddExt1.class).getExtensionName(AddExt1_ManualAdd1.class));
+        ExtensionLoader.resetExtensionLoader(AddExt1.class);
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/extension/ExtensionLoaderTest.java
@@ -326,6 +326,7 @@ public class ExtensionLoaderTest {
             assertThat(ext, instanceOf(AddExt1_ManualAdd2.class));
             assertEquals("impl1", getExtensionLoader(AddExt1.class).getExtensionName(AddExt1_ManualAdd2.class));
         }
+        ExtensionLoader.resetExtensionLoader(AddExt1.class);
     }
 
     @Test

--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
@@ -79,6 +79,7 @@ public class InternalThreadLocalTest {
         final InternalThreadLocal<String> internalThreadLocalString = new InternalThreadLocal<String>();
         internalThreadLocalString.set("value");
         Assertions.assertEquals(2, InternalThreadLocal.size(), "size method is wrong!");
+        InternalThreadLocal.removeAll();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
Observed that a few unit tests are flaky, and running them twice in the same JVM would result in failures(in the second runs). 

The target tests are the following:
-- dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_replaceExtension_Adaptive
-- dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_AddExtension
-- dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_replaceExtension
-- dubbo-common,org.apache.dubbo.common.threadlocal.InternalThreadLocalTest.testSize

The proposed changes fix those so that they become idempotent.

## Brief changelog
-- ExtensionLoaderTest.test_replaceExtension_Adaptive: Resets the ExtensionLoader for type 'AddExt3' at the end of the test.
-- dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_AddExtension: Resets the ExtensionLoader for type 'AddExt1' at the end of the test.
-- dubbo-common,org.apache.dubbo.common.extension.ExtensionLoaderTest.test_replaceExtension: Resets the ExtensionLoader for type 'AddExt1' at the end of the test.
-- dubbo-common,org.apache.dubbo.common.threadlocal.InternalThreadLocalTest.testSize: Call InternalThreadLocal.removeAll() to clear all the variables stored in the test run.

## Verifying this change
After the changes, those tests pass when running twice in the same JVM. In addition, all tests in the respective test classes continue to pass.

