### PR TITLE
clear all stored thread local variables in InternalThreadLocalTest.testSize

### DIFF
--- a/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
+++ b/dubbo-common/src/test/java/org/apache/dubbo/common/threadlocal/InternalThreadLocalTest.java
@@ -79,6 +79,7 @@ public class InternalThreadLocalTest {
         final InternalThreadLocal<String> internalThreadLocalString = new InternalThreadLocal<String>();
         internalThreadLocalString.set("value");
         Assertions.assertEquals(2, InternalThreadLocal.size(), "size method is wrong!");
+        InternalThreadLocal.removeAll();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
The test `dubbo-common,org.apache.dubbo.common.threadlocal.InternalThreadLocalTest.testSize` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

## Brief changelog

In `InternalThreadLocalTest.testSize()`, call `InternalThreadLocal.removeAll()` to clear all the thread local variables stored in the test run.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).
